### PR TITLE
Add Continuous Deployment to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 sudo: required
 language: python
-
 cache:
   apt: true
   directories:
   - $HOME/.cache/pip
   - $HOME/.ccache
-
 dist: trusty
-
 before_install: source build_tools/travis/before_install.sh
-
 env:
   global:
     # Directory where tests are run from
@@ -57,9 +53,21 @@ script: bash build_tools/travis/test_script.sh
 after_success: source build_tools/travis/after_success.sh
 
 notifications:
-    slack:
-      rooms:
-        - tgsmith61591-gh:mWyfLXzxRAHCKD2QRHWvHZaX#pyramid-cicd
-      on_success: always
-      on_failure: always
-      on_pull_requests: true
+  slack:
+    rooms:
+    - tgsmith61591-gh:mWyfLXzxRAHCKD2QRHWvHZaX#pyramid-cicd
+    on_success: always
+    on_failure: always
+    on_pull_requests: true
+
+deploy:
+  #server: https://test.pypi.org/legacy/ # Upload to pypi test server
+  distributions: "bdist_wheel" # Upload tar.gz and .whl files.
+  skip_upload_docs: true
+  skip_cleanup: true
+  on:
+    tags: true # Upload on tagged releases
+  provider: pypi
+  user: tgsmith61591.gh
+  password:
+    secure: TnuFYjjfLIZFMvIpt+KXhG7eeMf+KahTFKz3TE5o6obQXI9uxhN+2m4DX48QCJf2bAGxEKkLe9frXVM+Y/NUBm80sBIv4KvbmZkayMT4TZiJRzntIrsJCzem3jgExP1YUsSqrrmED7tvWpIZEqSJe+eUwHbsTAGhVBIz9mk7/CAP5UR8+0Oe+QKgjkX2VN/psoHOfFFQYTtE3L4pO05UlvyNIzNkrZ8WQ0PZ6wLHSIUCTC8ACFSzH9qWshYZ3+NVEX89l32V8A83nwV7k11yRonpXsSsrmsFYEDFf2h5b1it3VrOatwoNSMfUT+yvzhwuG2ibQv9dr/9mjlZl35VW1lE4qe2512FlVkTojATSVcMEz7cf1ZQdHtVYryqTOcyW9IgvZUJQoggMRSJLR9nLwxeSG1tfbN8NE3SQxnzeGxD+wz/XL26Tk5s9klQe7nI+rEXIR8lrN7zlOR7y9DQI7PiDHkbiIsy60p5Bi+0/pIrYaogCm7FuA4+23Y5m8Iv0/whWB3UIw5o6pVEzRnjdldeD37cLHfLLgwAU0fLnsT7Zdhc4chQhzfeTAy0o3LjdF0f8/vGnngqyxIvk+i/SrNibfB8fMWeduKse8z5mOU+eeLxqorbvyqPTHv0KG/6cBacOOHoSuwspxW1XQnBJp1R2GLSUOuHM9y3ScNrnpU=

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ if SETUPTOOLS_COMMANDS.intersection(sys.argv):
     print('Adding extra setuptools args')
     extra_setuptools_args = dict(
         zip_safe=False,  # the package can run out of an .egg file
-        include_package_data=True,
+        include_package_data=False,
+        package_data={'pyramid': ['*']},
         install_requires=REQUIREMENTS,
     )
 else:


### PR DESCRIPTION
This PR adds continuous deployment to Pypi on tagged commits.

## Notable mentionings

- It will be important to tag commits before pushing so that Travis will build the wheels properly. I believe there is a means to tag it through github itself, which I am fairly certain will not trigger the build of the wheels.
- The wheels that are built do not have OS, architecture, and OS version tied to them. Essentially two wheels are built - one for python 2 and one for python 3. 

@tgsmith61591 Thoughts?