### PR TITLE
[HOTFIX] 0.5.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ recursive-include pyramid/compat *.pyx *.pyd
 recursive-include pyramid/datasets *.pyx *.pyd
 recursive-include pyramid/utils *.pyx *.pyd
 include README.md
+include requirements.txt

--- a/pyramid/__init__.py
+++ b/pyramid/__init__.py
@@ -4,7 +4,7 @@
 #
 # The pyramid module
 
-__version__ = "0.5"
+__version__ = "0.5.1"
 
 try:
     # this var is injected in the setup build to enable

--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ def do_setup():
                                  'Programming Language :: Python :: 3.5',
                                  'Programming Language :: Python :: 3.6',
                                  ],
-                    keywords='sklearn scikit-learn arima timeseries',
+                    keywords='arima timeseries forecasting pyramid pyramid-arima scikit-learn statsmodels',
                     # this will only work for releases that have the appropriate tag...
                     download_url='https://github.com/%s/%s/archive/v%s.tar.gz' % (MAINTAINER_GIT, DISTNAME, VERSION),
                     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',


### PR DESCRIPTION
See #13. `requirements.txt` was not in the `MANIFEST.in`, and pip could not build from source. Now it can.