### PR TITLE
Add Linux wheel build with UCS-4 encoding for CPython 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,15 @@ matrix:
            COVERAGE=true SCIKIT_LEARN_VERSION="0.17.1" DEPLOY=true CACHEC=true
            DOCKER_IMAGE="quay.io/pypa/manylinux1_x86_64" DOCKER_CONTAINER_NAME="pyramidcontainer"
 
+    # This environment tests against Linux with CPython 2.7.x built with UCS-4 encoding
+    - os: linux
+      dist: trusty
+      services:
+        - docker
+      env: DISTRIB="conda" PYTHON_VERSION="2.7" CYTHON_VERSION="0.23.5"
+           COVERAGE=true SCIKIT_LEARN_VERSION="0.17.1" DEPLOY=true CACHEC=true
+           DOCKER_IMAGE="quay.io/pypa/manylinux1_x86_64" DOCKER_CONTAINER_NAME="pyramidcontainer" UCS_SETTING="ucs4"
+
     # This environment tests the same conditions as above, but tests against MAC OS X,
     # using virtualenv instead of the conda python distribution
     - os: osx

--- a/build_tools/travis/build_wheels.sh
+++ b/build_tools/travis/build_wheels.sh
@@ -7,6 +7,35 @@ if [[ "${DEPLOY}" != true ]]; then
     exit 0
 fi
 
+function build_wheel {
+    local pyver=$1
+    local arch=$2
+    local ucs_setting=$3
+
+    # https://www.python.org/dev/peps/pep-0513/#ucs-2-vs-ucs-4-builds
+    ucs_tag="m"
+    if [ "$ucs_setting" = "ucs4" ]; then
+        ucs_tag="${ucs_tag}u"
+    fi
+
+    ML_PYTHON_VERSION=$(python3 -c \
+        "print('cp{maj}{min}-cp{maj}{min}{ucs}'.format( \
+               maj='${pyver}'.split('.')[0], \
+	       min='${pyver}'.split('.')[1], \
+	       ucs='${ucs_tag}'))")
+
+    ML_IMAGE="quay.io/pypa/manylinux1_${arch}"
+    docker pull "${ML_IMAGE}"
+    docker run \
+        --name "${DOCKER_CONTAINER_NAME}" \
+        -v "${_root}":/io \
+        -e "PYMODULE=${PYMODULE}" \
+        -e "PYTHON_VERSION=${ML_PYTHON_VERSION}" \
+        "${ML_IMAGE}" "/io/build_tools/travis/build_manywheels_linux.sh"
+    sudo docker cp "${DOCKER_CONTAINER_NAME}:/io/dist/." "${_root}/dist/"
+    docker rm $(docker ps -a -f status=exited -q)
+}
+
 # Create base directory
 pushd $(dirname $0) > /dev/null
 _root=$(dirname $(dirname $(pwd -P))) # get one directory up from parent to get to root dir
@@ -16,23 +45,13 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
     echo "Building LINUX OS wheels"
 
     for pyver in ${PYTHON_VERSION}; do
-        ML_PYTHON_VERSION=$(python3 -c \
-            "print('cp{maj}{min}-cp{maj}{min}m'.format( \
-                   maj='${pyver}'.split('.')[0], \
-                   min='${pyver}'.split('.')[1]))")
-
-        for arch in x86_64; do
-            ML_IMAGE="quay.io/pypa/manylinux1_${arch}"
-            docker pull "${ML_IMAGE}"
-            docker run \
-                --name "${DOCKER_CONTAINER_NAME}" \
-                -v "${_root}":/io \
-                -e "PYMODULE=${PYMODULE}" \
-                -e "PYTHON_VERSION=${ML_PYTHON_VERSION}" \
-                "${ML_IMAGE}" "/io/build_tools/travis/build_manywheels_linux.sh"
-            sudo docker cp "${DOCKER_CONTAINER_NAME}:/io/dist/" "${_root}/dist/"
-            docker rm $(docker ps -a -f status=exited -q)
-        done
+        if [ -z "$UCS_SETTING" ] || [ "$UCS_SETTING" = "ucs2" ]; then
+            build_wheel $pyver "x86_64" "ucs2"
+        elif [ "$UCS_SETTING" = "ucs4" ]; then
+            build_wheel $pyver "x86_64" "ucs4"
+        else
+            echo "Unrecognized UCS_SETTING: ${UCS_SETTING}" 
+        fi
     done
 elif [ "${TRAVIS_OS_NAME}" == "osx" ]; then
     # this should be all that's required, right? We already removed the .egg-info


### PR DESCRIPTION
I'm unable to install Pyramid from a Wheel on an Amazon Linux EC2 machine. Based on [PEP 513](https://www.python.org/dev/peps/pep-0513/#ucs-2-vs-ucs-4-builds), a `--enable-unicode` flag needs to be passed when building CPython 2.x. (See: https://github.com/tgsmith61591/pyramid/issues/16).

The fix is to add another build to the Travis matrix to build with cp27mu. I refactored the Linux portion of the `build_wheels.sh` to expose the UCS setting and avoid hardcoding it. The rest of the builds will default to UCS-2 (which was the default previously, too) and UCS-4 will only be built when explicitly set in a particular job's env. In short, this simply adds a new build without affecting existing builds.